### PR TITLE
Add support for draft releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Shortcut workflow
-        uses: twinenyc/gh-action-shortcut-releases@v1.0.0
+        uses: ./
         with:
+          action: draft-release
+          tag: ${{ github.event.inputs.release-tag }}
           shortcutAccessToken: ${{ secrets.SHORTCUT_ACCESS_TOKEN }}
-          shortcutCompletedStateId: 500003738
-          commentOnTicket: true
+          targetShortcutStateId: 500003738

--- a/README.md
+++ b/README.md
@@ -1,28 +1,35 @@
 # GitHub action: Shortcut Release workflow
 
-This github action will update tickets in shortcut 
+This github action will update tickets in shortcut. It is useful to track tickets across github and Shortcut during release activities.
 
 ## Inputs
 
-### `shortcutAccessToken`
-
-**Required** The shortcut access token.
-
-### `shortcutCompletedStateId`
-
-**Optional** The ID of the shortcut state to transition tickets to. If this is omitted, the ticket will not be moved to a new state.
-
-### `commentOnTicket`
-
-**Optional** Should the job comment on the shortcut ticket?
-**Default** `false`
+| Name | Required? | Description |
+|--|--|--|
+| `action` | ✅ | Possible values: `release`, `draft-release` |
+| `tag` | ✅ | This is the tag that will be added to the comment title. example: `${{ github.release.tag_name }}`|
+|`shortcutAccessToken`| ✅ | Your Shortcut API access token. Be sure to keep this in a github secret.|
+| `targetShortcutStateId` | | The ID of the Shortcut state to transition tickets to. If this is omitted, the ticket will not be moved to a new state. |
 
 ## Example usage
 
+### Adding a comment to a Shortcut for a _drafted_ release
+
 ```yaml
-uses: twinenyc/gh-action-shortcut-releases@v1.0.0
+uses: twinenyc/gh-action-shortcut-releases@v2.0.0
 with:
+  action: draft-release
+  tag: ${{ github.event.inputs.release-tag }}
   shortcutAccessToken: ${{ secrets.SHORTCUT_ACCESS_TOKEN }}
-  shortcutCompletedStateId: 999999999
-  commentOnTicket: true
+```
+
+### Commenting and moving a ticket to "complete" for the release
+
+```yaml
+uses: twinenyc/gh-action-shortcut-releases@v2.0.0
+with:
+  action: release
+  tag: ${{ github.release.tag_name }}
+  shortcutAccessToken: ${{ secrets.SHORTCUT_ACCESS_TOKEN }}
+  targetShortcutStateId: 999999999
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,11 @@ async function main(releaseBody, releaseUrl, runId, tag, action, shortcutAccessT
 
 try {
   // retrieve github action context and input
-  const { payload, runId } = github.context;
+  const { payload, eventName, runId } = github.context;
+  if (eventName !== "release") {
+    core.setFailed("This action can only be run in a release workflow event type")
+  }
+
   const { body, html_url } = payload.release;
 
   // collect all the inputs that were manually passed in

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,9 @@ import { ShortcutClient } from '@useshortcut/client'
 import core from '@actions/core'
 import github from '@actions/github'
 
+const ACTION_RELEASE = 'release'
+const ACTION_DRAFT_RELEASE = 'draft-release'
+
 function extractStoryIds(content) {
   const regex = /(?<=sc|sc-|ch|ch-)\d{1,7}/gi
   const all = content.match(regex)
@@ -9,22 +12,29 @@ function extractStoryIds(content) {
   return unique
 }
 
-async function main(releaseBody, tag, releaseUrl, runId, shortcutAccessToken, completedStateId, commentOnTicket = true) {
+async function main(releaseBody, releaseUrl, runId, tag, action, shortcutAccessToken, targetShortcutStateId) {
   const shortcut = new ShortcutClient(shortcutAccessToken)
   const storyIds = extractStoryIds(releaseBody)
 
   for (const id of storyIds) {
-    if (completedStateId !== 'undefined') {
+    // move the ticket to the desired state if present
+    if (targetShortcutStateId !== '') {
       const stateId = parseInt(completedStateId)
-      await shortcut.updateStory(id, {
-        workflow_state_id: stateId
-      })
+      await shortcut.updateStory(id, { workflow_state_id: stateId })
     }
-    if (commentOnTicket) {
-      const commentText = `## 🚀 Release ${tag}\nLink: ${releaseUrl}\rrun id: ${runId}`
-      await shortcut.createStoryComment(id, {
-        text: commentText
-      })
+
+    // comment on the ticket according to the action
+    switch (action) {
+      case ACTION_RELEASE:
+        await shortcut.createStoryComment(id, {
+          text: `## 🚢 Released ${tag}\nLink: ${releaseUrl}\rRun id: ${runId}`
+        })
+        break;
+      case ACTION_DRAFT_RELEASE:
+        await shortcut.createStoryComment(id, {
+          text: `## 📦 Added to draft release ${tag}\nLink: ${releaseUrl}\rRun id: ${runId}`
+        })
+        break;
     }
   }
 
@@ -32,19 +42,18 @@ async function main(releaseBody, tag, releaseUrl, runId, shortcutAccessToken, co
 }
 
 try {
-  // make sure we are in a release event
-  const { payload, eventName, runId } = github.context;
-  if (eventName !== "release") {
-    console.warn("Skipping action because this is not a release event")
-    process.exit(0)
-  }
+  // retrieve github action context and input
+  const { payload, runId } = github.context;
+  const { body, html_url } = payload.release;
 
-  const { body, html_url, tag_name } = payload.release;
-  const token = core.getInput('shortcutAccessToken')
-  const completedStateId = core.getInput('shortcutCompletedStateId')
-  const commentOnTicket = core.getInput('commentOnTicket')
+  // collect all the inputs that were manually passed in
+  const action = core.getInput('action')
+  const tag = core.getInput('tag')
+  const shortcutAccessToken = core.getInput('shortcutAccessToken')
+  const targetShortcutStateId = core.getInput('targetShortcutStateId')
   
-  main(body, tag_name, html_url, runId, token, completedStateId, commentOnTicket)
+  // execute the action
+  main(body, html_url, runId, tag, action, shortcutAccessToken, targetShortcutStateId)
     .then((stories) => {
       console.log("Updated stories", stories)
     })


### PR DESCRIPTION
This breaking change makes it possible to update tickets during two release events:
* Drafting
* Publishing

The idea is that we can make it possible to search shortcut for tickets that are staged for a release so that it is easier to track items in the release.